### PR TITLE
Development

### DIFF
--- a/src/edu/uwo/csd/dcsim/core/EventComparator.java
+++ b/src/edu/uwo/csd/dcsim/core/EventComparator.java
@@ -6,11 +6,11 @@ public class EventComparator implements Comparator<Event> {
 
 	@Override
 	public int compare(Event e1, Event e2) {
-		if (e1.getTime() == e2.getTime()) {
-			return (int)(e1.getSendOrder() - e2.getSendOrder());
+        if (e1.getTime() == e2.getTime()) {
+			return new Long(e1.getSendOrder()).compareTo(e2.getSendOrder());
 		}
-		
-		return (int)(e1.getTime() - e2.getTime());
+
+		return new Long(e1.getTime()).compareTo(e2.getTime());
 	}
 
 	


### PR DESCRIPTION
The conversion to an int is causing a wrong insertion order for events. Anything greater than about 25 days is greater than the max signed int value. Sorry about the lousy commit history. Only forked once before and I completely forgot how it works.
