### PR TITLE
Make the provided examples run cleanly.

### DIFF
--- a/config/simulation.properties
+++ b/config/simulation.properties
@@ -30,4 +30,4 @@ metricPrecision=3
 approximateMVA=true
 
 #SLA for an application is not recorded for the first x time of its life-span (1 hour = 3600000)
-appSlaGraceTime=0 
+appSlaGraceTime=0


### PR DESCRIPTION
One bad character in the properties file.

Fixes #6 